### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: php
+
+php:
+ - 7.2
+ - 7.3
+
+before_script:
+ - phpenv config-rm xdebug.ini
+ - echo | pecl install channel://pecl.php.net/yaml-2.0.4
+ - git clone https://github.com/pmmp/pthreads.git
+ - cd pthreads
+ - git checkout 646dac62ae0d48c1ada7b007e15575fb84f7d71d
+ - phpize
+ - ./configure
+ - make
+ - make install
+ - cd ..
+ - echo "extension=pthreads.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+
+script:
+ - COMPOSER=phpstan-composer.json composer install --prefer-dist
+ - ./vendor/bin/phpstan analyze --no-progress --memory-limit=2G
+
+cache:
+ directories:
+  - $HOME/.composer/cache/files
+  - $HOME/.composer/cache/vcs
+
+notifications:
+ email: false


### PR DESCRIPTION
This demonstrates how to run PHPStan on a PocketMine-MP plugin using Travis CI, without any third party crap.